### PR TITLE
Share envs between the triggered workflows and the parent build

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -12,6 +12,11 @@ app:
 
 workflows:
   test:
+    envs:
+    - ENV_1: "1"
+    - ENV_2: "2"
+    - ENV_3: "3"
+    - ENV_4: "4"
     before_run:
     - audit-this-step
     steps:
@@ -24,6 +29,7 @@ workflows:
         - workflows: $TEST_WORKFLOWS
         - access_token: $ACCESS_TOKEN
         - wait_for_builds: "true"
+        - environment_key_list: "ENV_1\nENV_2\n$ENV_3\n$ENV_4\n"
 
   # ----------------------------------------------------------------
   # --- workflows to Share this step into a Step Library

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -31,6 +31,22 @@ workflows:
         - wait_for_builds: "true"
         - environment_key_list: "ENV_1\nENV_2\n$ENV_3\n$ENV_4\n"
 
+  test_shared_envs:
+    steps:
+    - script@1.1.5:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            
+            echo "ENV_1 = $ENV_1 ENV_2 = $ENV_2 ENV_3 = $ENV_3 ENV_4 = $ENV_4"
+            if [[ "$ENV_1" != "1" ]] || [[ "$ENV_2" != "2" ]] || [[ "$ENV_3"!= "3" ]] || [[ "$ENV_4" != "4" ]] ; then
+              exit 1;
+            else
+              echo "got all of the exported environments"
+            fi
+
   # ----------------------------------------------------------------
   # --- workflows to Share this step into a Step Library
   audit-this-step:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -41,7 +41,7 @@ workflows:
             set -e
             
             echo "ENV_1 = $ENV_1 ENV_2 = $ENV_2 ENV_3 = $ENV_3 ENV_4 = $ENV_4"
-            if [[ "$ENV_1" != "1" ]] || [[ "$ENV_2" != "2" ]] || [[ "$ENV_3"!= "3" ]] || [[ "$ENV_4" != "4" ]] ; then
+            if [[ "$ENV_1" != "1" ]] || [[ "$ENV_2" != "2" ]] || [[ "$ENV_3" != "3" ]] || [[ "$ENV_4" != "4" ]] ; then
               exit 1;
             else
               echo "got all of the exported environments"

--- a/bitrise/bitrise.go
+++ b/bitrise/bitrise.go
@@ -42,6 +42,12 @@ type StartResponse struct {
 	TriggeredWorkflow string `json:"triggered_workflow"`
 }
 
+// Environment ...
+type Environment struct {
+	MappedTo string `json:"mapped_to"`
+	Value    string `json:"value"`
+}
+
 // App ...
 type App struct {
 	Slug, AccessToken string
@@ -78,7 +84,7 @@ func (app App) GetBuild(buildSlug string) (Build, error) {
 }
 
 // StartBuild ...
-func (app App) StartBuild(workflow string, buildParams json.RawMessage, buildNumber string) (StartResponse, error) {
+func (app App) StartBuild(workflow string, buildParams json.RawMessage, buildNumber string, environments []Environment) (StartResponse, error) {
 	var params map[string]interface{}
 	if err := json.Unmarshal(buildParams, &params); err != nil {
 		return StartResponse{}, err
@@ -92,10 +98,15 @@ func (app App) StartBuild(workflow string, buildParams json.RawMessage, buildNum
 		"value":     buildNumber,
 	}
 
+	var envs []interface{}
 	if envs, ok := params["environments"].([]interface{}); ok {
 		params["environments"] = append(envs, sourceBuildNumber)
 	} else {
 		params["environments"] = []interface{}{sourceBuildNumber}
+	}
+
+	if len(environments) > 0 {
+		params["environments"] = append(envs, environments)
 	}
 
 	b, err := json.Marshal(params)

--- a/bitrise/bitrise.go
+++ b/bitrise/bitrise.go
@@ -92,22 +92,13 @@ func (app App) StartBuild(workflow string, buildParams json.RawMessage, buildNum
 	params["workflow_id"] = workflow
 	params["skip_git_status_report"] = true
 
-	sourceBuildNumber := map[string]interface{}{
-		"is_expand": true,
-		"mapped_to": "SOURCE_BITRISE_BUILD_NUMBER",
-		"value":     buildNumber,
+	sourceBuildNumber := Environment{
+		MappedTo: "SOURCE_BITRISE_BUILD_NUMBER",
+		Value:    buildNumber,
 	}
 
-	var envs []interface{}
-	if envs, ok := params["environments"].([]interface{}); ok {
-		params["environments"] = append(envs, sourceBuildNumber)
-	} else {
-		params["environments"] = []interface{}{sourceBuildNumber}
-	}
-
-	if len(environments) > 0 {
-		params["environments"] = append(envs, environments)
-	}
+	envs := []Environment{sourceBuildNumber}
+	params["environments"] = append(envs, environments...)
 
 	b, err := json.Marshal(params)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -97,7 +97,7 @@ func createEnvs(environmentKeys string) []bitrise.Environment {
 	var environments []bitrise.Environment
 	for _, key := range environmentsKeyList {
 		if key == "" {
-			break
+			continue
 		}
 
 		env := bitrise.Environment{

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ type Config struct {
 	AccessToken   stepconf.Secret `env:"access_token,required"`
 	WaitForBuilds string          `env:"wait_for_builds"`
 	Workflows     string          `env:"workflows,required"`
+	Environments  string          `env:"environment_key_list"`
 }
 
 func failf(s string, a ...interface{}) {
@@ -50,8 +51,9 @@ func main() {
 	log.Infof("Starting builds:")
 
 	var buildSlugs []string
+	environments := createEnvs(cfg.Environments)
 	for _, wf := range strings.Split(cfg.Workflows, "\n") {
-		startedBuild, err := app.StartBuild(wf, build.OriginalBuildParams, cfg.BuildNumber)
+		startedBuild, err := app.StartBuild(wf, build.OriginalBuildParams, cfg.BuildNumber, environments)
 		if err != nil {
 			failf("Failed to start build, error: %s", err)
 		}
@@ -86,4 +88,23 @@ func main() {
 	}); err != nil {
 		failf("An error occoured: %s", err)
 	}
+}
+
+func createEnvs(environmentKeys string) []bitrise.Environment {
+	environmentKeys = strings.Replace(environmentKeys, "$", "", -1)
+	environmentsKeyList := strings.Split(environmentKeys, "\n")
+
+	var environments []bitrise.Environment
+	for _, key := range environmentsKeyList {
+		if key == "" {
+			break
+		}
+
+		env := bitrise.Environment{
+			MappedTo: key,
+			Value:    os.Getenv(key),
+		}
+		environments = append(environments, env)
+	}
+	return environments
 }

--- a/main_test.go
+++ b/main_test.go
@@ -21,7 +21,7 @@ func Test_createEnvs(t *testing.T) {
 		{
 			name:            "one env",
 			environmentKeys: "ENV_1",
-			want:            []bitrise.Environment{bitrise.Environment{MappedTo: "ENV_1", Value: ""}},
+			want:            []bitrise.Environment{bitrise.Environment{MappedTo: "ENV_1", Value: "1"}},
 		},
 		{
 			name:            "multiple env",
@@ -29,19 +29,19 @@ func Test_createEnvs(t *testing.T) {
 			want: []bitrise.Environment{
 				bitrise.Environment{
 					MappedTo: "ENV_1",
-					Value:    "",
+					Value:    "1",
 				},
 				bitrise.Environment{
 					MappedTo: "ENV_2",
-					Value:    "",
+					Value:    "2",
 				},
 				bitrise.Environment{
 					MappedTo: "ENV_3",
-					Value:    "",
+					Value:    "3",
 				},
 				bitrise.Environment{
 					MappedTo: "ENV_4",
-					Value:    "",
+					Value:    "4",
 				},
 			},
 		},
@@ -51,19 +51,19 @@ func Test_createEnvs(t *testing.T) {
 			want: []bitrise.Environment{
 				bitrise.Environment{
 					MappedTo: "ENV_1",
-					Value:    "",
+					Value:    "1",
 				},
 				bitrise.Environment{
 					MappedTo: "ENV_2",
-					Value:    "",
+					Value:    "2",
 				},
 				bitrise.Environment{
 					MappedTo: "ENV_3",
-					Value:    "",
+					Value:    "3",
 				},
 				bitrise.Environment{
 					MappedTo: "ENV_4",
-					Value:    "",
+					Value:    "4",
 				},
 			},
 		},

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/bitrise-steplib/bitrise-step-build-router-start/bitrise"
+)
+
+func Test_createEnvs(t *testing.T) {
+	tests := []struct {
+		name            string
+		environmentKeys string
+		want            []bitrise.Environment
+	}{
+		{
+			name:            "empty",
+			environmentKeys: "",
+			want:            nil,
+		},
+		{
+			name:            "one env",
+			environmentKeys: "ENV_1",
+			want:            []bitrise.Environment{bitrise.Environment{MappedTo: "ENV_1", Value: ""}},
+		},
+		{
+			name:            "multiple env",
+			environmentKeys: "ENV_1\nENV_2\nENV_3\nENV_4",
+			want: []bitrise.Environment{
+				bitrise.Environment{
+					MappedTo: "ENV_1",
+					Value:    "",
+				},
+				bitrise.Environment{
+					MappedTo: "ENV_2",
+					Value:    "",
+				},
+				bitrise.Environment{
+					MappedTo: "ENV_3",
+					Value:    "",
+				},
+				bitrise.Environment{
+					MappedTo: "ENV_4",
+					Value:    "",
+				},
+			},
+		},
+		{
+			name:            "multiple env with $",
+			environmentKeys: "ENV_1\n$ENV_2\nENV_3\n$ENV_4",
+			want: []bitrise.Environment{
+				bitrise.Environment{
+					MappedTo: "ENV_1",
+					Value:    "",
+				},
+				bitrise.Environment{
+					MappedTo: "ENV_2",
+					Value:    "",
+				},
+				bitrise.Environment{
+					MappedTo: "ENV_3",
+					Value:    "",
+				},
+				bitrise.Environment{
+					MappedTo: "ENV_4",
+					Value:    "",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := createEnvs(tt.environmentKeys); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("createEnvs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/step.yml
+++ b/step.yml
@@ -34,6 +34,23 @@ inputs:
       summary: The workflow(s) to start. One workflow per line.
       description: The workflow(s) to start. One workflow per line.
       is_required: true
+  - environment_key_list:
+    opts:
+      title: Environments to share
+      summary: The keys of the envs which will be shared with the triggered workflows.
+      description: |-
+        The keys of the envs which will be shared with the triggered workflows
+
+        
+        **FORMAT** Seperate the keys `\n` character. E.g: 
+        `ENV_1
+        ENV_2
+        ENV_3`
+
+        
+        **NOTE** You can list the variables with the leading `$` or without it.
+      is_expand: false
+      is_required: false
   - wait_for_builds: "false"
     opts:
       title: Wait for builds

--- a/step.yml
+++ b/step.yml
@@ -46,9 +46,6 @@ inputs:
         `ENV_1
         ENV_2
         ENV_3`
-
-        
-        **NOTE** You can list the variables with the leading `$` or without it.
       is_expand: false
       is_required: false
   - wait_for_builds: "false"


### PR DESCRIPTION
# Description

feat: add an option to share the provided envs with the triggered workflows

- step.yml: add the environment_key_list input. With that you can specify which envs do you want to share with the triggered worklflows.
- bitrise/bitrise.go: add the Environment struct.
- test added to test the environment_key_list input parsing

# Click Up ticket / Github Issue / Discuss Thread

ClickUp: https://app.clickup.com/757956/762238/t/3rbn3
Discuss: https://discuss.bitrise.io/t/define-environment-variables-for-bitrise-start-build-step/5273

## Type of change

- [ ] Issue
- [x] Enhancement
- [ ] Maintenance
- [x] Feture request