### PR TITLE
fix: empty lines in workflow list can unintentionally trigger build

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,7 +52,8 @@ func main() {
 
 	var buildSlugs []string
 	environments := createEnvs(cfg.Environments)
-	for _, wf := range strings.Split(cfg.Workflows, "\n") {
+	trimmed := strings.TrimSpace(cfg.Workflows)
+	for _, wf := range strings.Split(trimmed, "\n") {
 		startedBuild, err := app.StartBuild(wf, build.OriginalBuildParams, cfg.BuildNumber, environments)
 		if err != nil {
 			failf("Failed to start build, error: %s", err)

--- a/main.go
+++ b/main.go
@@ -52,8 +52,8 @@ func main() {
 
 	var buildSlugs []string
 	environments := createEnvs(cfg.Environments)
-	trimmed := strings.TrimSpace(cfg.Workflows)
-	for _, wf := range strings.Split(trimmed, "\n") {
+	for _, wf := range strings.Split(strings.TrimSpace(cfg.Workflows), "\n") {
+		wf = strings.TrimSpace(wf)
 		startedBuild, err := app.StartBuild(wf, build.OriginalBuildParams, cfg.BuildNumber, environments)
 		if err != nil {
 			failf("Failed to start build, error: %s", err)


### PR DESCRIPTION
# Description

User stated that the Bitrise Start Build step causes infinite loop (starts the same workflow) if there's an extra newline in the input.

The issue is not the build starting itself. The build trigger API accepts an empty string for the workflow id parameter and if there is a trigger map item matching the request, it starts off the configured build in the trigger map. If there isn't, it returns HTTP 400.

Trimming the workflows input would most probably solve the issue though.

# Click Up ticket / Github Issue / Discuss Thread

https://app.clickup.com/t/3bzd9

## Type of change

Please select options that are relevant.

- [x] Issue
- [ ] Enhancement
- [ ] Maintenance
- [ ] Feature request