### PR TITLE
with a trailing slash

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,6 +107,7 @@ func main() {
 
 		if build.Status != 0 {
 			if strings.TrimSpace(cfg.BuildArtifactsSavePath) != "" {
+				fullBuildArtifactsSavePath := strings.TrimSuffix(cfg.BuildArtifactsSavePath, "/") + "/"
 				artifactsResponse, err := build.GetBuildArtifacts(app)
 				if err != nil {
 					log.Warnf("failed to get build artifacts, error: %s", err)
@@ -117,11 +118,11 @@ func main() {
 						log.Warnf("failed to get build artifact, error: %s", err)
 					}
 
-					downloadErr := artifactObj.Artifact.DownloadArtifact(strings.TrimSpace(cfg.BuildArtifactsSavePath) + artifactObj.Artifact.Title)
+					downloadErr := artifactObj.Artifact.DownloadArtifact(strings.TrimSpace(fullBuildArtifactsSavePath) + artifactObj.Artifact.Title)
 					if downloadErr != nil {
 						log.Warnf("failed to download artifact, error: %s", downloadErr)
 					}
-					log.Donef("Downloaded: " + artifactObj.Artifact.Title + " to path " + strings.TrimSpace(cfg.BuildArtifactsSavePath))
+					log.Donef("Downloaded: " + artifactObj.Artifact.Title + " to path " + strings.TrimSpace(fullBuildArtifactsSavePath))
 				}
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"filepath"
 
 	"github.com/bitrise-io/go-steputils/stepconf"
 	"github.com/bitrise-io/go-steputils/tools"

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"path/filepath"
 
 	"github.com/bitrise-io/go-steputils/stepconf"
 	"github.com/bitrise-io/go-steputils/tools"

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"filepath"
 
 	"github.com/bitrise-io/go-steputils/stepconf"
 	"github.com/bitrise-io/go-steputils/tools"
@@ -106,8 +107,9 @@ func main() {
 		}
 
 		if build.Status != 0 {
-			if strings.TrimSpace(cfg.BuildArtifactsSavePath) != "" {
-				fullBuildArtifactsSavePath := strings.TrimSuffix(cfg.BuildArtifactsSavePath, "/") + "/"
+			buildArtifactSaveDir := strings.TrimSpace(cfg.BuildArtifactsSavePath)
+			if buildArtifactSaveDir != "" {
+				fullBuildArtifactsSavePath := filepath.Join(buildArtifactSaveDir, artifactObj.Artifact.Title)
 				artifactsResponse, err := build.GetBuildArtifacts(app)
 				if err != nil {
 					log.Warnf("failed to get build artifacts, error: %s", err)
@@ -118,11 +120,11 @@ func main() {
 						log.Warnf("failed to get build artifact, error: %s", err)
 					}
 
-					downloadErr := artifactObj.Artifact.DownloadArtifact(strings.TrimSpace(fullBuildArtifactsSavePath) + artifactObj.Artifact.Title)
+					downloadErr := artifactObj.Artifact.DownloadArtifact(fullBuildArtifactsSavePath)
 					if downloadErr != nil {
 						log.Warnf("failed to download artifact, error: %s", downloadErr)
 					}
-					log.Donef("Downloaded: " + artifactObj.Artifact.Title + " to path " + strings.TrimSpace(fullBuildArtifactsSavePath))
+					log.Donef("Downloaded: " + artifactObj.Artifact.Title + " to path " + fullBuildArtifactsSavePath)
 				}
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -109,7 +109,6 @@ func main() {
 		if build.Status != 0 {
 			buildArtifactSaveDir := strings.TrimSpace(cfg.BuildArtifactsSavePath)
 			if buildArtifactSaveDir != "" {
-				fullBuildArtifactsSavePath := filepath.Join(buildArtifactSaveDir, artifactObj.Artifact.Title)
 				artifactsResponse, err := build.GetBuildArtifacts(app)
 				if err != nil {
 					log.Warnf("failed to get build artifacts, error: %s", err)
@@ -119,7 +118,7 @@ func main() {
 					if err != nil {
 						log.Warnf("failed to get build artifact, error: %s", err)
 					}
-
+					fullBuildArtifactsSavePath := filepath.Join(buildArtifactSaveDir, artifactObj.Artifact.Title)
 					downloadErr := artifactObj.Artifact.DownloadArtifact(fullBuildArtifactsSavePath)
 					if downloadErr != nil {
 						log.Warnf("failed to download artifact, error: %s", downloadErr)


### PR DESCRIPTION
# Description


build_artifacts_save_path isn't smart about a missing trailing slash.
Say I provide /path/to/dir as my save path. The step will save artifact.file to /path/to/dirartifact.file

This is inconvenient because the common input is $BITRISE_DEPLOY_DIR, which, by default, lacks a trailing slash.

# Click Up ticket / Github Issue / Discuss Thread
https://github.com/bitrise-steplib/bitrise-step-build-router-start/issues/23


## Type of change

Please select options that are relevant.

- [x] Issue
- [x] Enhancement