### PR TITLE
Remove warning about $BITRISE_DEPLOY_DIR

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -25,7 +25,7 @@ description: |-
        The build slugs you need are stored by the **Bitrise Start Build** Step in the `$ROUTER_STARTED_BUILD_SLUGS` Env Var. As long as the builds defined by the slugs are running, the Step will hold the build it is running in. The build will fail if any of the builds included in the Step fail.
     9. Optionally, you can save the build artifacts from the builds and configure the Step to abort all builds if any of the builds fail:
        - In **The path of the build artifacts** input, set where you'd like to save the artifacts. 
-         The value of the input must be an actual, existing path, ending with `/`. The `BITRISE_DEPLOY_DIR` Environment Variable is NOT a valid value.
+         The value of the input must be an actual, existing path, ending with `/`.
        - Set the **Abort all builds if one fails** input to either `yes` or `no`. 
        Please note that the build artifacts of child Workflows - Workflows triggered by this Step - will be only available if the child Workflow contains a **Deploy to Bitrise.io** Step.
   
@@ -109,7 +109,7 @@ inputs:
       description: |
           The path where build artifacts will be saved to if the **Wait for builds** input is set to `true`. 
       
-          Please note that the path must be an actual, existing path, ending with `/`. The `BITRISE_DEPLOY_DIR` Environment Variable is NOT a valid value. 
+          Please note that the path must be an actual, existing path, ending with `/`.  
       
           Note that when this Step triggers a Workflow, the artifacts of the triggered Workflow are only available to the Workflow that contains this Step, and not other Workflows. 
           The triggered Workflow MUST have a **Deploy to Bitrise.io** Step to deploy build artifacts!


### PR DESCRIPTION
# Description

This step description has warnings stating not to use the default deploy directory variable, but it works and makes sense, so it's unclear why. If this has a reason and it should remain, the description should be expanded to explain why.

This step just removes the lines about 

# Click Up ticket / Github Issue / Discuss Thread

If you have please include the ID / URL of the thread.

## Type of change

Please select options that are relevant.

- [ ] Issue
- [ ] Enhancement
- [ ] Maintenance
- [ ] Feture request