### PR TITLE
Don't treat "aborted with success" builds as failed

### DIFF
--- a/bitrise/bitrise.go
+++ b/bitrise/bitrise.go
@@ -366,7 +366,8 @@ func (app App) AbortBuild(buildSlug string, abortReason string) error {
 	b, err := json.Marshal(buildAbortParams{
 		AbortReason:       abortReason,
 		AbortWithSucces:   false,
-		SkipNotifications: true})
+		SkipNotifications: true,
+	})
 
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/v0.1/apps/%s/builds/%s/abort", app.BaseURL, app.Slug, buildSlug), bytes.NewReader(b))
 	if err != nil {
@@ -425,7 +426,7 @@ func (app App) WaitForBuilds(buildSlugs []string, statusChangeCallback func(buil
 				continue
 			}
 
-			if build.Status != 1 {
+			if build.Status != 1 && build.Status != 4 {
 				failed = true
 			}
 

--- a/bitrise/bitrise.go
+++ b/bitrise/bitrise.go
@@ -26,28 +26,28 @@ type Build struct {
 }
 
 // IsRunning ...
-func (b Build) IsRunning() bool {
-	return b.Status == 0
+func (build Build) IsRunning() bool {
+	return build.Status == 0
 }
 
 // IsSuccessful ...
-func (b Build) IsSuccessful() bool {
-	return b.Status == 1
+func (build Build) IsSuccessful() bool {
+	return build.Status == 1
 }
 
 // IsFailed ...
-func (b Build) IsFailed() bool {
-	return b.Status == 2
+func (build Build) IsFailed() bool {
+	return build.Status == 2
 }
 
 // IsAborted ...
-func (b Build) IsAborted() bool {
-	return b.Status == 3
+func (build Build) IsAborted() bool {
+	return build.Status == 3
 }
 
 // IsAbortedWithSuccess ...
-func (b Build) IsAbortedWithSuccess() bool {
-	return b.Status == 4
+func (build Build) IsAbortedWithSuccess() bool {
+	return build.Status == 4
 }
 
 type buildResponse struct {

--- a/bitrise/bitrise.go
+++ b/bitrise/bitrise.go
@@ -25,6 +25,31 @@ type Build struct {
 	OriginalBuildParams json.RawMessage `json:"original_build_params"`
 }
 
+// IsRunning ...
+func (b Build) IsRunning() bool {
+	return b.Status == 0
+}
+
+// IsSuccessful ...
+func (b Build) IsSuccessful() bool {
+	return b.Status == 1
+}
+
+// IsFailed ...
+func (b Build) IsFailed() bool {
+	return b.Status == 2
+}
+
+// IsAborted ...
+func (b Build) IsAborted() bool {
+	return b.Status == 3
+}
+
+// IsAbortedWithSuccess ...
+func (b Build) IsAbortedWithSuccess() bool {
+	return b.Status == 4
+}
+
 type buildResponse struct {
 	Data Build `json:"data"`
 }
@@ -421,12 +446,12 @@ func (app App) WaitForBuilds(buildSlugs []string, statusChangeCallback func(buil
 				status[buildSlug] = build.StatusText
 			}
 
-			if build.Status == 0 {
+			if build.IsRunning() {
 				running++
 				continue
 			}
 
-			if build.Status != 1 && build.Status != 4 {
+			if build.IsFailed() || build.IsAborted() {
 				failed = true
 			}
 


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context
Sometimes we would want to programatically abort builds that are not relevant for the PR (e.g. selective builds), but we don't want this to fail the build. This is true for fan-out builds too, the parent build shouldn't fail because of an "aborted with sucess" build.

### Changes

Treat build status 4 as a successful status

### Investigation details

https://devcenter.bitrise.io/en/builds/build-statuses.html

### Decisions

-