### PR TITLE
added new lines in environments to share input

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -88,13 +88,16 @@ inputs:
       title: Environments to share
       summary: The keys of the envs which will be shared with the triggered Workflows.
       description: |-
-        The keys of the envs which will be shared with the triggered Workflows
+        The keys of the envs which will be shared with the triggered Workflows.
 
         
-        **FORMAT** Seperate the keys with new line. E.g: 
-        `ENV_1
-        ENV_2
-        ENV_3`
+        **FORMAT** Seperate the keys with new line. E.g:
+        
+        `ENV_1`
+
+        `ENV_2`
+
+        `ENV_3`
       is_expand: false
       is_required: false
   - wait_for_builds: "false"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context
Currently on the WFE UI the env vars show up in one single line, we'd like to change that to eliminate confusion.

-->

### Changes
Currently on the WFE UI the env vars show up in one single line, we'd like to change that to eliminate confusion.
I added extra lines to the step.yml Environments to share input. 

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
