### PR TITLE
feat: export generated builds as json

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -30,7 +30,7 @@ workflows:
         inputs:
         - workflows: $TEST_WORKFLOWS
         - access_token: $ACCESS_TOKEN
-        - wait_for_builds: "true"
+        - wait_for_builds: "false"
         - environment_key_list: "ENV_1\nENV_2\n$ENV_3\n$ENV_4\n"
         - verbose: "yes"
 

--- a/step.yml
+++ b/step.yml
@@ -1,50 +1,50 @@
 title: "Bitrise Start Build"
 summary: Starts a new build with the specified Workflow(s).
 description: |-
-  The Step starts a new build of the same app with specified Workflow(s). On its own, the Step can be used to start multiple builds that run in parallel. In combination with the **Bitrise Wait for Build** Step, you can also add additional Steps to run in parallel while the triggered builds are running. For an example, check out our [Start builds from a parent Workflow](https://devcenter.bitrise.io/en/steps-and-workflows/generic-workflow-recipes/start--parallel--builds-from-the-workflow.html##) Workflow Recipe. 
-  You can put this Step in a Workflow that is triggered by a code push or pull request and use this Step to trigger multiple other builds at the same time. 
-  
+  The Step starts a new build of the same app with specified Workflow(s). On its own, the Step can be used to start multiple builds that run in parallel. In combination with the **Bitrise Wait for Build** Step, you can also add additional Steps to run in parallel while the triggered builds are running. For an example, check out our [Start builds from a parent Workflow](https://devcenter.bitrise.io/en/steps-and-workflows/generic-workflow-recipes/start--parallel--builds-from-the-workflow.html##) Workflow Recipe.
+  You can put this Step in a Workflow that is triggered by a code push or pull request and use this Step to trigger multiple other builds at the same time.
+
   To do that, you need multiple concurrencies - at least two! You also need a Personal Access Token to use the Step: [check out our guide](https://devcenter.bitrise.io/getting-started/account-security/#generating-personal-access-tokens-manually) on how to generate the token.
 
   If manual build approval is enabled for the project, this step won't be able to start new builds automatically.
 
-  ### Configuring the Step 
-  
+  ### Configuring the Step
+
   Before you run a build with this Step, make sure you have your Personal Access Token stored in a [Secret Environment Variable](https://devcenter.bitrise.io/builds/env-vars-secret-env-vars/#adding-a-secret-env-var).
-  
-  Note that all builds you trigger using this Step will have the same build number! 
-  
-     1. Set up at least two Workflows in the Workflow Editor: one will contain the Step, the other will be triggered by the Step. 
+
+  Note that all builds you trigger using this Step will have the same build number!
+
+     1. Set up at least two Workflows in the Workflow Editor: one will contain the Step, the other will be triggered by the Step.
        You can set up as many Workflows as you wish: your number of concurrencies limit the number of Workflows you can run simultaneously.
-    2. Add the **Bitrise Start Build** Step to the part of the Workflow where you want to trigger another build. 
+    2. Add the **Bitrise Start Build** Step to the part of the Workflow where you want to trigger another build.
     3. Add the Secret Env Var storing your Personal Access Token to the **Bitrise Access Token** input of the **Bitrise Start Build** Step: click the **Select secret variable** button, and choose the key you created.
-    4. Find the **Workflows** input of the **Bitrise Start Build** Step, and add the Workflow(s) you want to run. 
+    4. Find the **Workflows** input of the **Bitrise Start Build** Step, and add the Workflow(s) you want to run.
     5. In the **Environments to share** input, add Environment Variables (Env Vars) that you want to share between the builds triggered by the Step.
-    6. (Optional) You can set the **Wait for builds** input to `true` if you would like to pause the current build until the triggered build(s) are finished. 
+    6. (Optional) You can set the **Wait for builds** input to `true` if you would like to pause the current build until the triggered build(s) are finished.
     7. (Optional) You can add any Step you would like to run in parallel while the triggered Workflow(s) are running in the parent Workflow.
        Make sure to add the **Bitrise Wait for Build** Step to the end of Workflow.
     8. Add the Secret Env Var storing your Personal Access Token to the **Bitrise Access Token** input of the **Bitrise Wait for Build** Step: click the **Select secret variable** button, and choose the key you created.
-    9. In the **Build slugs** input, define the builds for the Step. 
+    9. In the **Build slugs** input, define the builds for the Step.
        The build slugs you need are stored by the **Bitrise Start Build** Step in the `$ROUTER_STARTED_BUILD_SLUGS` Env Var. As long as the builds defined by the slugs are running, the Step will hold the build it is running in. The build will fail if any of the builds included in the Step fail.
     10. Optionally, you can save the build artifacts from the builds and configure the Step to abort all builds if any of the builds fail:
-       - In **The path of the build artifacts** input, set where you'd like to save the artifacts. 
+       - In **The path of the build artifacts** input, set where you'd like to save the artifacts.
          The value of the input must be an actual, existing path, ending with `/`.
-       - Set the **Abort all builds if one fails** input to either `yes` or `no`. 
+       - Set the **Abort all builds if one fails** input to either `yes` or `no`.
        Please note that the build artifacts of child Workflows - Workflows triggered by this Step - will be only available if the child Workflow contains a **Deploy to Bitrise.io** Step.
-  
-  ### Troubleshooting 
 
-  - Make sure you have both the **Bitrise Start Build** and the **Bitrise Wait for Build** Steps in the right place in your initial Workflow. 
-  - Always check all your builds: if your concurrencies are taken up by other builds, this Step cannot start new ones. 
-  - Your Personal Access Token can expire! Make sure it's still valid - without it, you can't start new builds with this Step.  
+  ### Troubleshooting
 
-  ### Useful links 
+  - Make sure you have both the **Bitrise Start Build** and the **Bitrise Wait for Build** Steps in the right place in your initial Workflow.
+  - Always check all your builds: if your concurrencies are taken up by other builds, this Step cannot start new ones.
+  - Your Personal Access Token can expire! Make sure it's still valid - without it, you can't start new builds with this Step.
+
+  ### Useful links
 
   - [Starting parallel builds with a single Workflow](https://devcenter.bitrise.io/builds/triggering-builds/trigger-multiple-workflows/)
-  - [Start builds from a parent Workflow](https://devcenter.bitrise.io/en/steps-and-workflows/generic-workflow-recipes/start--parallel--builds-from-the-workflow.html##)  
-  
+  - [Start builds from a parent Workflow](https://devcenter.bitrise.io/en/steps-and-workflows/generic-workflow-recipes/start--parallel--builds-from-the-workflow.html##)
 
-  ### Related Steps 
+
+  ### Related Steps
 
   - [Bitrise Wait for Build](https://www.bitrise.io/integrations/steps/build-router-wait)
   - [Bitrise Run](https://www.bitrise.io/integrations/steps/bitrise-run)
@@ -71,8 +71,8 @@ inputs:
       summary: Your access token
       description: |
           Your access token
-          
-          To acquire a `Personal Access Token` for your user, sign in with that user on [bitrise.io](https://bitrise.io),  
+
+          To acquire a `Personal Access Token` for your user, sign in with that user on [bitrise.io](https://bitrise.io),
           go to your `Account Settings` page, and select the [Security tab](https://www.bitrise.io/me/profile#/security) on the left side.
       is_required: true
       is_expand: true
@@ -90,9 +90,9 @@ inputs:
       description: |-
         The keys of the envs which will be shared with the triggered Workflows.
 
-        
+
         **FORMAT** Seperate the keys with new line. E.g:
-        
+
         `ENV_1`
 
         `ENV_2`
@@ -114,9 +114,9 @@ inputs:
       title: The path of the build artifacts
       summary: The path that the build artifacts will be saved to if the **Wait for builds** input is set to `true`.
       description: |
-          The path where build artifacts will be saved to if the **Wait for builds** input is set to `true`. 
+          The path where build artifacts will be saved to if the **Wait for builds** input is set to `true`.
 
-          Note that when this Step triggers a Workflow, the artifacts of the triggered Workflow are only available to the Workflow that contains this Step, and not other Workflows. 
+          Note that when this Step triggers a Workflow, the artifacts of the triggered Workflow are only available to the Workflow that contains this Step, and not other Workflows.
           The triggered Workflow MUST have a **Deploy to Bitrise.io** Step to deploy build artifacts!
       is_required: false
       is_sensitive: false
@@ -145,3 +145,8 @@ outputs:
       title: "Started Build Slugs"
       summary: "Newline separated list of started build slugs."
       description: "Newline separated list of started build slugs."
+  - ROUTER_STARTED_BUILDS:
+    opts:
+      title: "Started Builds"
+      summary: "JSON array of builds and each has slug, number url and workflow"
+      description: "JSON array of builds and each has slug, number url and workflow"


### PR DESCRIPTION
I encountered a problem when I tried to compile a list of all initiated builds for a GitHub release note. Simply using the build slug to summarize all the information was proving to be difficult. Therefore, I decided to extract additional data on all initiated builds and export it in a JSON format. As JSON format it makes the reuse more flexible for future Bitrise workflow steps.

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Exporting only the build slug is not enough for future Bitrise workflow steps.

Resolves: https://github.com/bitrise-steplib/bitrise-step-build-router-start/issues/39


### Changes

- use package `encoding/json`
- save the builds in an array
- marshal to a JSON string
- add new export definition in step.yml

### Investigation details

No investigation details

### Decisions

No other decisions
